### PR TITLE
Switch to compile-time tuple-based storage

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,12 +1,17 @@
-BasedOnStyle: LLVM
+BasedOnStyle: Google
 ColumnLimit: 120
 IndentWidth: 4
 TabWidth: 4
 UseTab: ForIndentation
 AlignEscapedNewlines: DontAlign
-AllowShortFunctionsOnASingleLine: Inline
 AlwaysBreakTemplateDeclarations: true
 BreakBeforeBinaryOperators: NonAssignment
 BreakBeforeBraces: Custom
+AllowShortLambdasOnASingleLine: Empty # or Empty or None or Inline
 BraceWrapping:
   AfterFunction: true
+  BeforeLambdaBody: true
+  AfterControlStatement: true
+  # AfterNamespace: true
+BinPackArguments: false
+PointerAlignment: Left

--- a/.clang-format
+++ b/.clang-format
@@ -14,4 +14,6 @@ BraceWrapping:
   AfterControlStatement: true
   # AfterNamespace: true
 BinPackArguments: false
+DerivePointerAlignment: false
 PointerAlignment: Left
+ReferenceAlignment: Left

--- a/README.md
+++ b/README.md
@@ -1,10 +1,11 @@
+
 # EasyS: Manage entities and components with minimal fuss
 
 [![Build and test](https://github.com/raphaelmayer/easys/actions/workflows/cmake-build-and-test.yml/badge.svg)](https://github.com/raphaelmayer/easys/actions/workflows/cmake-build-and-test.yml)
 
 EasyS is a minimalist, header-only C++ library designed to streamline the development of applications using the Entity Component System (ECS) architecture. With a focus on simplicity, flexibility, and ease of use, it offers developers an unopinionated foundation to build efficient, high-performance systems without the overhead of external dependencies.
 
-This library embraces a dynamic design philosophy, allowing new component types to be introduced at runtime without requiring prior (compile-time) registration. This flexibility sets it apart, making it well-suited for scenarios where extensibility and runtime adaptability are essential.
+**The library now uses a static design approach**, requiring all component types to be registered at compile time through template parameters. This shift from runtime to compile-time registration improves performance, enables stronger type safety, and eliminates runtime type checks, while still maintaining a clean and lightweight API.
 
 **TLDR:** EasyS provides the essential tools to create, manage, and iterate on entities and components with minimal fuss.
 
@@ -29,8 +30,10 @@ struct Position {
 
 int main()
 {
-	// Create an instance of the ECS class to manage our entities and components.
-	ECS ecs;
+	using namespace Easys;
+  
+	// Create an instance of the ECS class and register all component types.
+	ECS<Position> ecs;
 
 	// Create a new entity. An entity is just a number.
 	Entity entity = ecs.addEntity();
@@ -56,7 +59,7 @@ Check out the ```/examples``` directory for more examples on how to use this lib
 
 ### Requirements
 
-EasyS requires a compiler that supports at least C++20. This is mainly because of the use of concepts and might change in the future.
+EasyS requires a compiler that supports at least C++20. This is because of the use of concepts and templated lambda functions and is subject to change. 
 
 ### Direct inclusion
 
@@ -127,7 +130,7 @@ target_link_libraries(your_target_name PRIVATE easys)
 
 ### ECS Library Documentation
 
-This documentation section provides a comprehensive overview of the user-facing interface for the ECS (Entity Component System) library.
+All types and functions are defined within the `Easys` namespace. This section documents the core interface of the EasyS ECS library, including entity management and component operations..
 
 #### Constructor
 
@@ -146,30 +149,32 @@ This documentation section provides a comprehensive overview of the user-facing 
   - Checks if an entity exists within the ECS.
 - **`const std::set<Entity>& getEntities() const`**
   - Returns a reference to the set of all entities.
+- **`const std::vector<Entity>& getEntitiesByComponent<T>() const`**
+  - Returns a vector of entities that have a component of type `T`.
+- **`std::vector<Entity> getEntitiesByComponents<Ts...>() const`**
+  - Returns a vector of entities that have all of the specified component types `Ts...`.
 - **`size_t getEntityCount() const`**
   - Returns the total number of entities in the ECS.
 
 #### Component Management
 
-- **`void addComponent(const Entity e, const T c)`**
+- **`void addComponent<T>(const Entity e, const T c)`**
   - Adds a component of type `T` to an entity `e`. If the entity is already associated with a component `T`, update it.
-- **`void removeComponent(const Entity e)`**
+- **`void removeComponent<T>(const Entity e)`**
   - Removes a component of type `T` from an entity `e`.
-- **`T& getComponent(const Entity e)`**
-  - Retrieves a reference to a component of type `T` from an entity `e`. If the entity does not have a component of this type, an exception is thrown.
-- **`bool hasComponent(const Entity e) const`**
-  - Checks if an entity `e` has a component of type `T`. This method can be used with any type `T` and entity `e`.
-- **`const std::vector<Entity>& getEntitiesByComponent() const`**
-  - Returns a vector of entities that have a component of type `T`.
-- **`std::vector<Entity> getEntitiesByComponents() const`**
-  - Returns a vector of entities that have all of the specified component types `Ts...`.
-- **`size_t getComponentCount() const`**
-  - Returns the total count of components within the ECS. When template parameters are specified, it returns the count for the specified component types.
+- **`void removeComponents<Ts...>(const Entity e)`**
+	- Removes components of types `Ts...` from an entity `e`. If the template parameters are omitted, it removes all components from the entity.
+- **`T& getComponent<T>(const Entity e)`**
+  - Retrieves a reference to a component of type `T` from an entity `e`. 
+- **`bool hasComponent<T>(const Entity e) const`**
+  - Checks if an entity `e` has a component of type `T`.
+- **`size_t getComponentCount<Ts...>() const`**
+  - Returns the total count of components of types `Ts...` within the ECS. If template parameters are omitted, it returns the total count of all component types.
  
 #### Clearing Methods
 
 - **`void clearComponents()`**
-  - Clears components from all entities within the ECS. When template parameters are specified, only the specified types of components are cleared.
+  - Removes components of types `Ts...` from all entities within the ECS. If template parameters are omitted only all types of components are cleared.
 - **`void clear()`**
   - Clears all entities and components from the ECS, resetting it to its initial state.
 

--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ All types and functions are defined within the `Easys` namespace. This section d
  
 #### Clearing Methods
 
-- **`void clearComponents()`**
+- **`void clearComponents<Ts...>()`**
   - Removes components of types `Ts...` from all entities within the ECS. If template parameters are omitted only all types of components are cleared.
 - **`void clear()`**
   - Clears all entities and components from the ECS, resetting it to its initial state.
@@ -182,9 +182,8 @@ All types and functions are defined within the `Easys` namespace. This section d
 
 Users are expected to:
 
-- **Automatic Creation of Component Types:** When you first interact with a new component type (for example, by adding it to an entity or retrieving its component set), the ECS automatically creates the necessary storage for that type. There is no need to explicitly register or define component types beforehand.
-  *This dynamic design allows new component types to be introduced at runtime without requiring compile-time registration.*
-- **Verify Entity Component Composition:** Before retrieving or modifying a component, ensure the entity possesses the component. Attempting to access a component not associated with an entity will result in an exception.
+- **Register all Components at Compile-Time:** All component types must be specified as template parameters when instantiating the ECS. Accessing a foreign component will result in a compiler error.
+- **Check Component Presence Before Access:** Always verify that an entity has a given component before accessing it. Calling `getComponent<T>(entity)` on an entity that lacks `T` will throw a `Easys::KeyNotFoundException`.
 
 ## Configuration Options
 

--- a/examples/basic.cpp
+++ b/examples/basic.cpp
@@ -25,11 +25,11 @@ int main()
 	ecs.addComponent<Position>(entity, {10.0f, 20.0f});
 
 	// Update the component.
-	auto &component = ecs.getComponent<Position>(entity);
+	auto& component = ecs.getComponent<Position>(entity);
 	component.x = 0.0f;
 
 	// Retrieve the Position component from the entity to read or modify it.
-	Position &pos = ecs.getComponent<Position>(entity);
+	Position& pos = ecs.getComponent<Position>(entity);
 	std::cout << "Position: " << pos.x << ", " << pos.y << std::endl;
 
 	return 0;

--- a/examples/basic.cpp
+++ b/examples/basic.cpp
@@ -16,7 +16,7 @@ int main()
 	using namespace Easys;
 
 	// Create an instance of the ECS class to manage our entities and components.
-	ECS ecs;
+	ECS<Position> ecs;
 
 	// Create a new entity. An entity is just a number.
 	Entity entity = ecs.addEntity();

--- a/examples/basic2.cpp
+++ b/examples/basic2.cpp
@@ -19,7 +19,7 @@ int main()
 {
 	using namespace Easys;
 
-	ECS ecs;
+	ECS<Position, Velocity> ecs;
 
 	// Creating multiple entities and adding components
 	Entity firstEntity = ecs.addEntity();
@@ -36,21 +36,25 @@ int main()
 	std::cout << "First Entity Velocity: " << firstVel.dx << ", " << firstVel.dy << std::endl;
 
 	// Querying all entities
-	for (auto entity : ecs.getEntities()) {
-		if (ecs.hasComponent<Position>(entity)) {
+	for (auto entity : ecs.getEntities())
+	{
+		if (ecs.hasComponent<Position>(entity))
+		{
 			Position &pos = ecs.getComponent<Position>(entity);
 			std::cout << "Entity " << entity << " Position: " << pos.x << ", " << pos.y << std::endl;
 		}
 	}
 
 	// Querying entities that have a single component
-	for (auto entity : ecs.getEntitiesByComponent<Position>()) {
+	for (auto entity : ecs.getEntitiesByComponent<Position>())
+	{
 		Position &pos = ecs.getComponent<Position>(entity);
 		std::cout << "Entity " << entity << " Position: " << pos.x << ", " << pos.y << std::endl;
 	}
 
 	// Querying entities that have multiple components
-	for (auto entity : ecs.getEntitiesByComponents<Position, Velocity>()) {
+	for (auto entity : ecs.getEntitiesByComponents<Position, Velocity>())
+	{
 		Position &pos = ecs.getComponent<Position>(entity);
 		Velocity &vel = ecs.getComponent<Velocity>(entity);
 		std::cout << "Entity " << entity << " Position: " << pos.x << ", " << pos.y << " Velocity: " << vel.dx << ", "
@@ -58,9 +62,11 @@ int main()
 	}
 
 	// Attempting to access a component not present on an entity
-	try {
-		Velocity &secondVel = ecs.getComponent<Velocity>(secondEntity); // This will throw an exception
-	} catch (const KeyNotFoundException) {
+	try
+	{
+		Velocity &secondVel = ecs.getComponent<Velocity>(secondEntity);  // This will throw an exception
+	} catch (const KeyNotFoundException)
+	{
 		std::cout << "Second Entity does not have a Velocity component." << std::endl;
 	}
 

--- a/examples/basic2.cpp
+++ b/examples/basic2.cpp
@@ -30,8 +30,8 @@ int main()
 	// secondEntity does not have a Velocity component
 
 	// Querying components from entities
-	Position &firstPos = ecs.getComponent<Position>(firstEntity);
-	Velocity &firstVel = ecs.getComponent<Velocity>(firstEntity);
+	Position& firstPos = ecs.getComponent<Position>(firstEntity);
+	Velocity& firstVel = ecs.getComponent<Velocity>(firstEntity);
 	std::cout << "First Entity Position: " << firstPos.x << ", " << firstPos.y << std::endl;
 	std::cout << "First Entity Velocity: " << firstVel.dx << ", " << firstVel.dy << std::endl;
 
@@ -40,7 +40,7 @@ int main()
 	{
 		if (ecs.hasComponent<Position>(entity))
 		{
-			Position &pos = ecs.getComponent<Position>(entity);
+			Position& pos = ecs.getComponent<Position>(entity);
 			std::cout << "Entity " << entity << " Position: " << pos.x << ", " << pos.y << std::endl;
 		}
 	}
@@ -48,15 +48,15 @@ int main()
 	// Querying entities that have a single component
 	for (auto entity : ecs.getEntitiesByComponent<Position>())
 	{
-		Position &pos = ecs.getComponent<Position>(entity);
+		Position& pos = ecs.getComponent<Position>(entity);
 		std::cout << "Entity " << entity << " Position: " << pos.x << ", " << pos.y << std::endl;
 	}
 
 	// Querying entities that have multiple components
 	for (auto entity : ecs.getEntitiesByComponents<Position, Velocity>())
 	{
-		Position &pos = ecs.getComponent<Position>(entity);
-		Velocity &vel = ecs.getComponent<Velocity>(entity);
+		Position& pos = ecs.getComponent<Position>(entity);
+		Velocity& vel = ecs.getComponent<Velocity>(entity);
 		std::cout << "Entity " << entity << " Position: " << pos.x << ", " << pos.y << " Velocity: " << vel.dx << ", "
 		          << vel.dy << std::endl;
 	}
@@ -64,7 +64,7 @@ int main()
 	// Attempting to access a component not present on an entity
 	try
 	{
-		Velocity &secondVel = ecs.getComponent<Velocity>(secondEntity);  // This will throw an exception
+		Velocity& secondVel = ecs.getComponent<Velocity>(secondEntity);  // This will throw an exception
 	} catch (const KeyNotFoundException)
 	{
 		std::cout << "Second Entity does not have a Velocity component." << std::endl;

--- a/examples/simple_gameloop.cpp
+++ b/examples/simple_gameloop.cpp
@@ -16,12 +16,12 @@ using ECS = Easys::ECS<Position, Velocity>;
 
 // Example system which updates the player position based on the player velocity.
 struct System {
-	void update(ECS &ecs)
+	void update(ECS& ecs)
 	{
 		for (Easys::Entity e : ecs.getEntitiesByComponents<Position, Velocity>())
 		{
-			Position &pos = ecs.getComponent<Position>(e);
-			const Velocity &vel = ecs.getComponent<Velocity>(e);
+			Position& pos = ecs.getComponent<Position>(e);
+			const Velocity& vel = ecs.getComponent<Velocity>(e);
 
 			pos.x += vel.vx;
 			pos.y += vel.vy;

--- a/examples/simple_gameloop.cpp
+++ b/examples/simple_gameloop.cpp
@@ -12,13 +12,14 @@ struct Velocity {
 	Velocity(float vx = 0.0f, float vy = 0.0f) : vx(vx), vy(vy) {}
 };
 
-using namespace Easys;
+using ECS = Easys::ECS<Position, Velocity>;
 
 // Example system which updates the player position based on the player velocity.
 struct System {
 	void update(ECS &ecs)
 	{
-		for (Entity e : ecs.getEntitiesByComponents<Position, Velocity>()) {
+		for (Easys::Entity e : ecs.getEntitiesByComponents<Position, Velocity>())
+		{
 			Position &pos = ecs.getComponent<Position>(e);
 			const Velocity &vel = ecs.getComponent<Velocity>(e);
 
@@ -35,15 +36,16 @@ int main()
 	System system;
 
 	// Create an entity and add components
-	Entity player = ecs.addEntity();
+	Easys::Entity player = ecs.addEntity();
 	ecs.addComponent(player, Position(1.0f, 1.0f));
 	ecs.addComponent(player, Velocity(0.1f, 0.0f));
 
 	bool isRunning = true;
-	while (isRunning) {
+	while (isRunning)
+	{
 		// handle input (for example in another system)
 
-		system.update(ecs); // handle system update
+		system.update(ecs);  // handle system update
 
 		// handle rendering (for example in another system)
 		Position p = ecs.getComponent<Position>(player);

--- a/include/easys/ecs.hpp
+++ b/include/easys/ecs.hpp
@@ -104,7 +104,7 @@ class ECS {
 	}
 
 	template <typename... Ts>
-	inline std::vector<Entity>& getEntitiesByComponents() const
+	inline std::vector<Entity> getEntitiesByComponents() const
 	{
 		return registry_.template getEntitiesByComponents<Ts...>();
 	}

--- a/include/easys/ecs.hpp
+++ b/include/easys/ecs.hpp
@@ -22,10 +22,11 @@ class ECS {
 		}
 	}
 
-	// This constructor is for initialising the ECS with a set of specific entities. I decided against an
-	// addEntity(Entity) method to discourage tampering with entities too much. I think this really should be the ECS's
+	// This constructor is for initialising the ECS with a set of specific
+	// entities. I decided against an addEntity(Entity) method to discourage
+	// tampering with entities too much. I think this really should be the ECS's
 	// responsibility.
-	ECS(const std::set<Entity> &oldEntities)
+	ECS(const std::set<Entity>& oldEntities)
 	{
 		for (Entity entity = 0; entity < MAX_ENTITIES; entity++)
 		{
@@ -36,7 +37,7 @@ class ECS {
 		}
 	}
 
-	Entity addEntity()
+	inline Entity addEntity()
 	{
 		if (getEntityCount() < MAX_ENTITIES)
 		{
@@ -45,11 +46,12 @@ class ECS {
 			entities_.insert(e);
 			return e;
 		}
-		// throwing an exception here seems kind of drastic, but on the other hand maybe not
+		// throwing an exception here seems kind of drastic, but on the other hand
+		// maybe not
 		throw std::runtime_error("MAX NUMBER OF ENTITIES REACHED!");
 	}
 
-	void removeEntity(const Entity e)
+	inline void removeEntity(const Entity e)
 	{
 		// Remove all components associated with the entity
 		registry_.removeComponents(e);
@@ -59,74 +61,74 @@ class ECS {
 		availableEntityIds_.push(e);
 	}
 
-	bool hasEntity(const Entity e) const { return entities_.contains(e); }
+	inline bool hasEntity(const Entity e) const { return entities_.contains(e); }
 
-	const std::set<Entity> &getEntities() const { return entities_; }
+	inline const std::set<Entity>& getEntities() const { return entities_; }
 
-	size_t getEntityCount() const { return entities_.size(); }
+	inline size_t getEntityCount() const { return entities_.size(); }
 
 	template <typename T>
-	void addComponent(const Entity e, const T c)
+	inline void addComponent(const Entity e, T component)
 	{
-		registry_.addComponent(e, c);
+		registry_.addComponent(e, std::move(component));
 	}
 
 	template <typename T>
-	void removeComponent(const Entity e)
+	inline void removeComponent(const Entity e)
 	{
 		registry_.template removeComponent<T>(e);
 	}
 
 	template <typename T>
-	T &getComponent(const Entity e)
+	inline T& getComponent(const Entity e)
 	{
 		return registry_.template getComponent<T>(e);
 	}
 
 	template <typename T>
-	const T &getComponent(const Entity e) const
+	inline const T& getComponent(const Entity e) const
 	{
-		return registry_.template  getComponent<T>(e);
+		return registry_.template getComponent<T>(e);
 	}
 
 	template <typename T>
-	bool hasComponent(const Entity e) const
+	inline bool hasComponent(const Entity e) const
 	{
-		return registry_.template  hasComponent<T>(e);
+		return registry_.template hasComponent<T>(e);
 	}
 
 	template <typename T>
-	const std::vector<Entity> &getEntitiesByComponent() const
+	inline const std::vector<Entity>& getEntitiesByComponent() const
 	{
-		return registry_.template  getEntitiesByComponent<T>();
+		return registry_.template getEntitiesByComponent<T>();
 	}
 
 	template <typename... Ts>
-	std::vector<Entity> getEntitiesByComponents() const
+	inline std::vector<Entity>& getEntitiesByComponents() const
 	{
-		return registry_.template  getEntitiesByComponents<Ts...>();
+		return registry_.template getEntitiesByComponents<Ts...>();
 	}
 
-	size_t getComponentCount() const { return registry_.size(); }
+	inline size_t getComponentCount() const { return registry_.size(); }
 
 	template <typename... Ts>
-	size_t getComponentCount() const
+	inline size_t getComponentCount() const
 	{
-		return registry_.template  size<Ts...>();
+		return registry_.template size<Ts...>();
 	}
 
-	void clear()
+	inline void clear()
 	{
 		registry_.clear();
 		clearEntities();
 	}
 
-	void clearComponents() { registry_.clear(); }
+	inline void clearComponents() { registry_.clear(); }
 
 	template <typename... Ts>
-	void clearComponents()
+	inline void clearComponents()
 	{
-		registry_.template  clear<Ts...>();
+		registry_.template clear<Ts...>();
 	}
 
    private:

--- a/include/easys/ecs.hpp
+++ b/include/easys/ecs.hpp
@@ -74,37 +74,37 @@ class ECS {
 	template <typename T>
 	void removeComponent(const Entity e)
 	{
-		registry_.removeComponent<T>(e);
+		registry_.template removeComponent<T>(e);
 	}
 
 	template <typename T>
 	T &getComponent(const Entity e)
 	{
-		return registry_.getComponent<T>(e);
+		return registry_.template getComponent<T>(e);
 	}
 
 	template <typename T>
 	const T &getComponent(const Entity e) const
 	{
-		return registry_.getComponent<T>(e);
+		return registry_.template  getComponent<T>(e);
 	}
 
 	template <typename T>
 	bool hasComponent(const Entity e) const
 	{
-		return registry_.hasComponent<T>(e);
+		return registry_.template  hasComponent<T>(e);
 	}
 
 	template <typename T>
 	const std::vector<Entity> &getEntitiesByComponent() const
 	{
-		return registry_.getEntitiesByComponent<T>();
+		return registry_.template  getEntitiesByComponent<T>();
 	}
 
 	template <typename... Ts>
 	std::vector<Entity> getEntitiesByComponents() const
 	{
-		return registry_.getEntitiesByComponents<Ts...>();
+		return registry_.template  getEntitiesByComponents<Ts...>();
 	}
 
 	size_t getComponentCount() const { return registry_.size(); }
@@ -112,7 +112,7 @@ class ECS {
 	template <typename... Ts>
 	size_t getComponentCount() const
 	{
-		return registry_.size<Ts...>();
+		return registry_.template  size<Ts...>();
 	}
 
 	void clear()
@@ -126,7 +126,7 @@ class ECS {
 	template <typename... Ts>
 	void clearComponents()
 	{
-		registry_.clear<Ts...>();
+		registry_.template  clear<Ts...>();
 	}
 
    private:

--- a/include/easys/ecs.hpp
+++ b/include/easys/ecs.hpp
@@ -1,21 +1,25 @@
 #pragma once
 
-#include "entity.hpp"
-#include "registry.hpp"
 #include <functional>
 #include <iostream>
 #include <memory>
 #include <queue>
 #include <set>
 
+#include "entity.hpp"
+#include "registry.hpp"
+
 namespace Easys {
 
+template <typename... AllComponentTypes>
 class ECS {
-  public:
+   public:
 	ECS()
 	{
 		for (Entity entity = 0; entity < MAX_ENTITIES; entity++)
+		{
 			availableEntityIds_.push(entity);
+		}
 	}
 
 	// This constructor is for initialising the ECS with a set of specific entities. I decided against an
@@ -24,15 +28,18 @@ class ECS {
 	ECS(const std::set<Entity> &oldEntities)
 	{
 		for (Entity entity = 0; entity < MAX_ENTITIES; entity++)
+		{
 			if (oldEntities.contains(entity))
 				entities_.insert(entity);
 			else
 				availableEntityIds_.push(entity);
+		}
 	}
 
 	Entity addEntity()
 	{
-		if (getEntityCount() < MAX_ENTITIES) {
+		if (getEntityCount() < MAX_ENTITIES)
+		{
 			Entity e = availableEntityIds_.front();
 			availableEntityIds_.pop();
 			entities_.insert(e);
@@ -122,10 +129,10 @@ class ECS {
 		registry_.clear<Ts...>();
 	}
 
-  private:
+   private:
 	std::queue<Entity> availableEntityIds_;
 	std::set<Entity> entities_;
-	Registry registry_;
+	Registry<AllComponentTypes...> registry_;
 
 	void clearEntities()
 	{
@@ -134,9 +141,8 @@ class ECS {
 		std::queue<Entity> empty;
 		std::swap(availableEntityIds_, empty);
 
-		for (Entity entity = 0; entity < MAX_ENTITIES; entity++)
-			availableEntityIds_.push(entity);
+		for (Entity entity = 0; entity < MAX_ENTITIES; entity++) availableEntityIds_.push(entity);
 	}
 };
 
-} // namespace Easys
+}  // namespace Easys

--- a/include/easys/entity.hpp
+++ b/include/easys/entity.hpp
@@ -1,7 +1,8 @@
 #pragma once
 
-#include "config.hpp"
 #include <stdint.h>
+
+#include "config.hpp"
 
 // stdint.h needs to be included for uint32_t for Ubuntu, otherwise fails the build.
 
@@ -10,4 +11,4 @@ namespace Easys {
 using Entity = EASYS_ENTITY_TYPE;
 const Entity MAX_ENTITIES = EASYS_ENTITY_LIMIT;
 
-} // namespace Easys
+}  // namespace Easys

--- a/include/easys/registry.hpp
+++ b/include/easys/registry.hpp
@@ -11,25 +11,6 @@
 
 namespace Easys {
 
-// This exception is currently unused, as an unknown component type will
-// implicitly create a componentSet<ComponentType> when encountered for the
-// first time. Maybe not the best solution? On the other hand usually you don't
-// randomly query random types from the ECS, so it should be fine.	Better
-// than throwing an exception, especially since the previous implementation
-// resulted in ~5x worse performance across the board.
-class ComponentTypeNotFoundException : public std::exception {
-   public:
-	ComponentTypeNotFoundException(const std::string& key)
-	    : msg_("ComponentTypeNotFoundException: " + key + " not found")
-	{
-	}
-
-	const char* what() const noexcept override { return msg_.c_str(); }
-
-   private:
-	std::string msg_;
-};
-
 template <typename... AllComponentTypes>
 class Registry {
    private:
@@ -73,6 +54,7 @@ class Registry {
 	ComponentType& getComponent(const Entity entity)
 	{
 		auto& componentSet = getComponentSet<ComponentType>();
+		// could be optimized with direct access. get() calls contains() internally
 		return componentSet.get(entity);
 	}
 
@@ -80,6 +62,7 @@ class Registry {
 	const ComponentType& getComponent(const Entity entity) const
 	{
 		const auto& componentSet = getComponentSet<ComponentType>();
+		// could be optimized with direct access. get() calls contains() internally
 		return componentSet.get(entity);
 	}
 

--- a/include/easys/registry.hpp
+++ b/include/easys/registry.hpp
@@ -1,76 +1,86 @@
 #pragma once
 
-#include "entity.hpp"
-#include "sparse_set.hpp"
 #include <any>
 #include <stdexcept>
 #include <typeindex>
 #include <unordered_map>
 #include <vector>
 
+#include "entity.hpp"
+#include "sparse_set.hpp"
+
 namespace Easys {
 
-// This exception is currently unused, as an unknown component type will implicitly create a componentSet<ComponentType>
-// when encountered for the first time. Maybe not the best solution? On the other hand usually you don't randomly query
-// random types from the ECS, so it should be fine.	Better than throwing an exception, especially since the previous
-// implementation resulted in ~5x worse performance across the board.
+// This exception is currently unused, as an unknown component type will
+// implicitly create a componentSet<ComponentType> when encountered for the
+// first time. Maybe not the best solution? On the other hand usually you don't
+// randomly query random types from the ECS, so it should be fine.	Better
+// than throwing an exception, especially since the previous implementation
+// resulted in ~5x worse performance across the board.
 class ComponentTypeNotFoundException : public std::exception {
-  public:
-	ComponentTypeNotFoundException(const std::string &key)
+   public:
+	ComponentTypeNotFoundException(const std::string& key)
 	    : msg_("ComponentTypeNotFoundException: " + key + " not found")
 	{
 	}
 
-	const char *what() const noexcept override { return msg_.c_str(); }
+	const char* what() const noexcept override { return msg_.c_str(); }
 
-  private:
+   private:
 	std::string msg_;
 };
 
+template <typename... AllComponentTypes>
 class Registry {
-  private:
-	mutable std::unordered_map<std::type_index, SparseSet<Entity, std::any>> componentSets;
+   private:
+	mutable std::tuple<SparseSet<Entity, AllComponentTypes>...> componentSets;
 
-  public:
+   public:
 	template <typename ComponentType>
-	void addComponent(const Entity entity, const ComponentType component)
+	void addComponent(const Entity entity, const ComponentType& component)
 	{
-		auto [it, inserted] = componentSets.try_emplace(typeid(ComponentType));
-		if (inserted) {
-			it->second = SparseSet<Entity, std::any>();
-		}
-		it->second.set(entity, std::any(component));
+		auto& componentSet = getComponentSet<ComponentType>();
+		componentSet.set(entity, std::move(component));
 	}
 
 	template <typename ComponentType>
 	void removeComponent(const Entity entity)
 	{
-		auto &componentSet = getComponentSet<ComponentType>();
+		auto& componentSet = getComponentSet<ComponentType>();
 		componentSet.remove(entity);
 	}
 
 	void removeComponents(const Entity entity)
 	{
-		for (auto &[type, componentSet] : componentSets)
-			componentSet.remove(entity);
+		forEachComponentType<AllComponentTypes...>(
+		    [&]<typename Component>()
+		    {
+			    removeComponent<Component>(entity);
+		    });
+	}
+
+	template <typename... ComponentTypes>
+	void removeComponents(const Entity entity)
+	{
+		forEachComponentType<ComponentTypes...>(
+		    [&]<typename Component>()
+		    {
+			    removeComponent<Component>(entity);
+		    });
 	}
 
 	template <typename ComponentType>
-	ComponentType &getComponent(const Entity entity)
+	ComponentType& getComponent(const Entity entity)
 	{
-		auto &componentSet = getComponentSet<ComponentType>();
-		return *std::any_cast<ComponentType>(&componentSet.get(entity));
-		// could be optimized by omitting any checks and accessing elements directly, i.e
-		// return *std::any_cast<ComponentType>(&componentSet[entity]);
+		auto& componentSet = getComponentSet<ComponentType>();
+		return componentSet.get(entity);
 	}
 
 	template <typename ComponentType>
-	const ComponentType &getComponent(const Entity entity) const
+	const ComponentType& getComponent(const Entity entity) const
 	{
-		const auto &componentSet = getComponentSet<ComponentType>();
-		return *std::any_cast<ComponentType>(&componentSet.get(entity));
-		// could be optimized by omitting any checks and accessing elements directly, i.e
-		// return *std::any_cast<ComponentType>(&componentSet[entity]);
+		const auto& componentSet = getComponentSet<ComponentType>();
+		return componentSet.get(entity);
 	}
 
 	template <typename ComponentType>
@@ -80,7 +90,7 @@ class Registry {
 	}
 
 	template <typename ComponentType>
-	const std::vector<Entity> &getEntitiesByComponent() const
+	const std::vector<Entity>& getEntitiesByComponent() const
 	{
 		return getComponentSet<ComponentType>().getKeys();
 	}
@@ -92,27 +102,31 @@ class Registry {
 		bool isFirstComponentType = true;
 
 		// Helper lambda to intersect two sorted vectors
-		auto intersect = [](const std::vector<Entity> &v1, const std::vector<Entity> &v2) {
+		auto intersect = [](const std::vector<Entity>& v1, const std::vector<Entity>& v2)
+		{
 			std::vector<Entity> v_intersection;
 			std::set_intersection(v1.begin(), v1.end(), v2.begin(), v2.end(), std::back_inserter(v_intersection));
 			return v_intersection;
 		};
 
 		// Iterate over each component type and intersect entities
-		forEachComponentType<ComponentTypes...>([this, &entities, &isFirstComponentType, &intersect](auto dummy) {
-			using T = decltype(dummy);
-			// We sort here. This is not optimal. We probably want to lazily sort based on a flag
-			// (refer to github issue #7):
-			auto componentEntities = getEntitiesByComponent<T>();
-			std::sort(componentEntities.begin(), componentEntities.end());
-			// Temporary fix end
-			if (isFirstComponentType) {
-				entities = componentEntities;
-				isFirstComponentType = false;
-			} else {
-				entities = intersect(entities, componentEntities);
-			}
-		});
+		forEachComponentType<ComponentTypes...>(
+		    [this, &entities, &isFirstComponentType, &intersect]<typename T>()
+		    {
+			    // We sort here. This is not optimal. We probably want to lazily
+			    // sort based on a flag (refer to github issue #7):
+			    auto componentEntities = getEntitiesByComponent<T>();
+			    std::sort(componentEntities.begin(), componentEntities.end());
+			    // Temporary fix end
+			    if (isFirstComponentType)
+			    {
+				    entities = componentEntities;
+				    isFirstComponentType = false;
+			    } else
+			    {
+				    entities = intersect(entities, componentEntities);
+			    }
+		    });
 
 		return entities;
 	}
@@ -120,8 +134,13 @@ class Registry {
 	size_t size() const
 	{
 		size_t totalSize = 0;
-		for (auto &[type, componentSet] : componentSets)
-			totalSize += componentSet.size();
+
+		forEachComponentType<AllComponentTypes...>(
+		    [this, &totalSize]<typename T>()
+		    {
+			    totalSize += getComponentSet<T>().size();
+		    });
+
 		return totalSize;
 	}
 
@@ -129,54 +148,65 @@ class Registry {
 	size_t size() const
 	{
 		size_t totalSize = 0;
-		forEachComponentType<ComponentTypes...>([this, &totalSize](auto dummy) {
-			using T = decltype(dummy);
-			if (hasComponentType<T>()) // we ignore unknown component types. should we throw an exception?
-				totalSize += getComponentSet<T>().size();
-		});
+
+		forEachComponentType<ComponentTypes...>(
+		    [this, &totalSize]<typename T>()
+		    {
+			    totalSize += getComponentSet<T>().size();
+		    });
+
 		return totalSize;
 	}
 
-	void clear() { componentSets.clear(); }
+	void clear()
+	{
+		forEachComponentType<AllComponentTypes...>(
+		    [this]<typename T>()
+		    {
+			    getComponentSet<T>().clear();
+		    });
+	}
 
 	template <typename... ComponentTypes>
 	void clear()
 	{
-		forEachComponentType<ComponentTypes...>([this](auto dummy) {
-			using T = decltype(dummy);
-			if (hasComponentType<T>()) // we ignore unknown component types. should we throw an exception?
-				componentSets.erase(typeid(T));
-		});
+		forEachComponentType<ComponentTypes...>(
+		    [this]<typename T>()
+		    {
+			    getComponentSet<T>().clear();
+		    });
 	}
 
-  private:
+   private:
+	template <typename T>
+	static constexpr bool isRegisteredComponent = (std::is_same_v<T, AllComponentTypes> || ...);
+
 	template <typename... ComponentTypes, typename Func>
-	void forEachComponentType(Func f) const
+	void forEachComponentType(Func&& f) const
 	{
-		// static assert as a fallback
-		static_assert(sizeof...(ComponentTypes) > 0, "You must specify at least one component type.");
-		(f(ComponentTypes{}), ...);
-	}
+		// MSVC does not support multiple expressions in a fold statement so we use this small helper
+		auto staticAssertAndCall = [&f]<typename T>()
+		{
+			static_assert(isRegisteredComponent<T>, "Tried to access an unregistered component type in ECS.");
+			f.template operator()<T>();
+		};
 
-  private:
-	template <typename ComponentType>
-	SparseSet<Entity, std::any> &getComponentSet()
-	{
-		return componentSets[typeid(ComponentType)];
+		(staticAssertAndCall.template operator()<ComponentTypes>(), ...);
 	}
 
 	template <typename ComponentType>
-	const SparseSet<Entity, std::any> &getComponentSet() const
+	SparseSet<Entity, ComponentType>& getComponentSet()
 	{
-		return componentSets[typeid(ComponentType)];
+		static_assert(isRegisteredComponent<ComponentType>, "Tried to access an unregistered component type.");
+		return std::get<SparseSet<Entity, ComponentType>>(componentSets);
 	}
 
-	// Check if a ComponentType has been initialized
 	template <typename ComponentType>
-	bool hasComponentType() const
+	const SparseSet<Entity, ComponentType>& getComponentSet() const
 	{
-		return componentSets.find(typeid(ComponentType)) != componentSets.end();
+		static_assert(isRegisteredComponent<ComponentType>, "Tried to access an unregistered component type.");
+		return std::get<SparseSet<Entity, ComponentType>>(componentSets);
 	}
 };
 
-} // namespace Easys
+}  // namespace Easys

--- a/include/easys/registry.hpp
+++ b/include/easys/registry.hpp
@@ -18,20 +18,20 @@ class Registry {
 
    public:
 	template <typename ComponentType>
-	void addComponent(const Entity entity, const ComponentType& component)
+	inline void addComponent(const Entity entity, const ComponentType& component)
 	{
 		auto& componentSet = getComponentSet<ComponentType>();
 		componentSet.set(entity, std::move(component));
 	}
 
 	template <typename ComponentType>
-	void removeComponent(const Entity entity)
+	inline void removeComponent(const Entity entity)
 	{
 		auto& componentSet = getComponentSet<ComponentType>();
 		componentSet.remove(entity);
 	}
 
-	void removeComponents(const Entity entity)
+	inline void removeComponents(const Entity entity)
 	{
 		forEachComponentType<AllComponentTypes...>(
 		    [&]<typename Component>()
@@ -41,7 +41,7 @@ class Registry {
 	}
 
 	template <typename... ComponentTypes>
-	void removeComponents(const Entity entity)
+	inline void removeComponents(const Entity entity)
 	{
 		forEachComponentType<ComponentTypes...>(
 		    [&]<typename Component>()
@@ -51,7 +51,7 @@ class Registry {
 	}
 
 	template <typename ComponentType>
-	ComponentType& getComponent(const Entity entity)
+	inline ComponentType& getComponent(const Entity entity)
 	{
 		auto& componentSet = getComponentSet<ComponentType>();
 		// could be optimized with direct access. get() calls contains() internally
@@ -59,7 +59,7 @@ class Registry {
 	}
 
 	template <typename ComponentType>
-	const ComponentType& getComponent(const Entity entity) const
+	inline const ComponentType& getComponent(const Entity entity) const
 	{
 		const auto& componentSet = getComponentSet<ComponentType>();
 		// could be optimized with direct access. get() calls contains() internally
@@ -67,19 +67,19 @@ class Registry {
 	}
 
 	template <typename ComponentType>
-	bool hasComponent(const Entity entity) const
+	inline bool hasComponent(const Entity entity) const
 	{
 		return getComponentSet<ComponentType>().contains(entity);
 	}
 
 	template <typename ComponentType>
-	const std::vector<Entity>& getEntitiesByComponent() const
+	inline const std::vector<Entity>& getEntitiesByComponent() const
 	{
 		return getComponentSet<ComponentType>().getKeys();
 	}
 
 	template <typename... ComponentTypes>
-	std::vector<Entity> getEntitiesByComponents() const
+	inline std::vector<Entity> getEntitiesByComponents() const
 	{
 		std::vector<Entity> entities;
 		bool isFirstComponentType = true;
@@ -114,7 +114,7 @@ class Registry {
 		return entities;
 	}
 
-	size_t size() const
+	inline size_t size() const
 	{
 		size_t totalSize = 0;
 
@@ -128,7 +128,7 @@ class Registry {
 	}
 
 	template <typename... ComponentTypes>
-	size_t size() const
+	inline size_t size() const
 	{
 		size_t totalSize = 0;
 
@@ -141,7 +141,7 @@ class Registry {
 		return totalSize;
 	}
 
-	void clear()
+	inline void clear()
 	{
 		forEachComponentType<AllComponentTypes...>(
 		    [this]<typename T>()
@@ -151,7 +151,7 @@ class Registry {
 	}
 
 	template <typename... ComponentTypes>
-	void clear()
+	inline void clear()
 	{
 		forEachComponentType<ComponentTypes...>(
 		    [this]<typename T>()
@@ -165,7 +165,7 @@ class Registry {
 	static constexpr bool isRegisteredComponent = (std::is_same_v<T, AllComponentTypes> || ...);
 
 	template <typename... ComponentTypes, typename Func>
-	void forEachComponentType(Func&& f) const
+	inline void forEachComponentType(Func&& f) const
 	{
 		// MSVC does not support multiple expressions in a fold statement so we use this small helper
 		auto staticAssertAndCall = [&f]<typename T>()
@@ -178,14 +178,14 @@ class Registry {
 	}
 
 	template <typename ComponentType>
-	SparseSet<Entity, ComponentType>& getComponentSet()
+	inline SparseSet<Entity, ComponentType>& getComponentSet()
 	{
 		static_assert(isRegisteredComponent<ComponentType>, "Tried to access an unregistered component type.");
 		return std::get<SparseSet<Entity, ComponentType>>(componentSets);
 	}
 
 	template <typename ComponentType>
-	const SparseSet<Entity, ComponentType>& getComponentSet() const
+	inline const SparseSet<Entity, ComponentType>& getComponentSet() const
 	{
 		static_assert(isRegisteredComponent<ComponentType>, "Tried to access an unregistered component type.");
 		return std::get<SparseSet<Entity, ComponentType>>(componentSets);

--- a/include/easys/sparse_set.hpp
+++ b/include/easys/sparse_set.hpp
@@ -11,12 +11,12 @@
 namespace Easys {
 
 class KeyNotFoundException : public std::exception {
-  public:
+   public:
 	KeyNotFoundException(const std::string &key) : msg_("KeyNotFoundException: " + key + " not found") {}
 
 	const char *what() const noexcept override { return msg_.c_str(); }
 
-  private:
+   private:
 	std::string msg_;
 };
 
@@ -27,20 +27,18 @@ concept UnsignedIntegral = std::is_integral_v<T> && std::is_unsigned_v<T>;
 
 template <UnsignedIntegral Key, typename Value>
 class SparseSet {
-  private:
-	std::vector<Key> sparse;   // Large, indexed by keys
-	std::vector<Key> dense;    // Compact, stores keys
-	std::vector<Value> values; // Parallel to dense, stores values
+   private:
+	std::vector<Key> sparse;    // Large, indexed by keys
+	std::vector<Key> dense;     // Compact, stores keys
+	std::vector<Value> values;  // Parallel to dense, stores values
 
-  public:
+   public:
 	// Ensure the sparse array can accommodate the given key
 	void accommodate(const Key key)
 	{
-		if (key >= maxSize())
-			throw std::length_error("Key exceeds the maximum size limit.");
+		if (key >= maxSize()) throw std::length_error("Key exceeds the maximum size limit.");
 
-		if (key >= sparse.size())
-			sparse.resize(key * 2 + 1, std::numeric_limits<Key>::max());
+		if (key >= sparse.size()) sparse.resize(key * 2 + 1, std::numeric_limits<Key>::max());
 	}
 
 	// Associate a value with a key
@@ -48,19 +46,22 @@ class SparseSet {
 	{
 		accommodate(key);
 
-		if (sparse[key] == std::numeric_limits<Key>::max()) { // max Key to indicate not set
+		if (sparse[key] == std::numeric_limits<Key>::max())
+		{  // max Key to indicate not set
 			sparse[key] = static_cast<Key>(values.size());
 			dense.push_back(key);
 			values.push_back(value);
-		} else {
-			values[sparse[key]] = value; // Key already has a value, update it
+		} else
+		{
+			values[sparse[key]] = value;  // Key already has a value, update it
 		}
 	}
 
 	// Retrieve a value by key
 	const Value &get(const Key key) const
 	{
-		if (!contains(key)) {
+		if (!contains(key))
+		{
 			throw KeyNotFoundException(std::to_string(key));
 		}
 		return values[sparse[key]];
@@ -69,7 +70,8 @@ class SparseSet {
 	// Retrieve a value by key
 	Value &get(const Key key)
 	{
-		if (!contains(key)) {
+		if (!contains(key))
+		{
 			throw KeyNotFoundException(std::to_string(key));
 		}
 		return values[sparse[key]];
@@ -81,7 +83,8 @@ class SparseSet {
 	// Remove a value associated with a key
 	void remove(const Key key)
 	{
-		if (contains(key)) {
+		if (contains(key))
+		{
 			// Move the last value to the removed spot to keep dense packed
 			Key indexOfRemoved = sparse[key];
 			values[indexOfRemoved] = values.back();
@@ -103,7 +106,8 @@ class SparseSet {
 	template <typename Func>
 	void forEach(Func f)
 	{
-		for (size_t i = 0; i < values.size(); ++i) {
+		for (size_t i = 0; i < values.size(); ++i)
+		{
 			f(dense[i], values[i]);
 		}
 	}
@@ -132,4 +136,4 @@ class SparseSet {
 	}
 };
 
-} // namespace Easys
+}  // namespace Easys

--- a/include/easys/sparse_set.hpp
+++ b/include/easys/sparse_set.hpp
@@ -12,9 +12,9 @@ namespace Easys {
 
 class KeyNotFoundException : public std::exception {
    public:
-	KeyNotFoundException(const std::string &key) : msg_("KeyNotFoundException: " + key + " not found") {}
+	KeyNotFoundException(const std::string& key) : msg_("KeyNotFoundException: " + key + " not found") {}
 
-	const char *what() const noexcept override { return msg_.c_str(); }
+	const char* what() const noexcept override { return msg_.c_str(); }
 
    private:
 	std::string msg_;
@@ -50,7 +50,7 @@ class SparseSet {
 	// Associate a value with a key
 
 	// Associate a value with a key
-	inline void set(const Key key, const Value &value)
+	inline void set(const Key key, const Value& value)
 	{
 		accommodate(key);
 
@@ -66,7 +66,7 @@ class SparseSet {
 	}
 
 	// move semantics overload
-	inline void set(const Key key, Value &&value)
+	inline void set(const Key key, Value&& value)
 	{
 		accommodate(key);
 
@@ -82,7 +82,7 @@ class SparseSet {
 	}
 
 	// Retrieve a value by key
-	inline const Value &get(const Key key) const
+	inline const Value& get(const Key key) const
 	{
 		if (!contains(key))
 		{
@@ -92,7 +92,7 @@ class SparseSet {
 	}
 
 	// Retrieve a value by key
-	inline Value &get(const Key key)
+	inline Value& get(const Key key)
 	{
 		if (!contains(key))
 		{
@@ -101,8 +101,8 @@ class SparseSet {
 		return values[sparse[key]];
 	}
 
-	inline const Value &operator[](const Key key) const { return values[sparse[key]]; }
-	inline Value &operator[](const Key key) { return values[sparse[key]]; }
+	inline const Value& operator[](const Key key) const { return values[sparse[key]]; }
+	inline Value& operator[](const Key key) { return values[sparse[key]]; }
 
 	// Remove a value associated with a key
 	inline void remove(const Key key)
@@ -143,11 +143,11 @@ class SparseSet {
 
 	constexpr size_t size() const { return dense.size(); }
 
-	inline const std::vector<Key> &getKeys() const { return dense; }
+	inline const std::vector<Key>& getKeys() const { return dense; }
 
-	inline std::vector<Value> &getValues() { return values; }
+	inline std::vector<Value>& getValues() { return values; }
 
-	inline const std::vector<Value> &getValues() const { return values; }
+	inline const std::vector<Value>& getValues() const { return values; }
 
 	constexpr size_t maxSize() const noexcept
 	{

--- a/include/easys/sparse_set.hpp
+++ b/include/easys/sparse_set.hpp
@@ -34,15 +34,23 @@ class SparseSet {
 
    public:
 	// Ensure the sparse array can accommodate the given key
-	void accommodate(const Key key)
+	inline void accommodate(const Key key)
 	{
-		if (key >= maxSize()) throw std::length_error("Key exceeds the maximum size limit.");
+		if (key >= maxSize())
+		{
+			throw std::length_error("Key exceeds the maximum size limit.");
+		}
 
-		if (key >= sparse.size()) sparse.resize(key * 2 + 1, std::numeric_limits<Key>::max());
+		if (key >= sparse.size())
+		{
+			sparse.resize(key * 2 + 1, std::numeric_limits<Key>::max());
+		}
 	}
 
 	// Associate a value with a key
-	void set(const Key key, const Value &value)
+
+	// Associate a value with a key
+	inline void set(const Key key, const Value &value)
 	{
 		accommodate(key);
 
@@ -57,8 +65,24 @@ class SparseSet {
 		}
 	}
 
+	// move semantics overload
+	inline void set(const Key key, Value &&value)
+	{
+		accommodate(key);
+
+		if (sparse[key] == std::numeric_limits<Key>::max())
+		{
+			sparse[key] = static_cast<Key>(values.size());
+			dense.push_back(key);
+			values.push_back(std::move(value));
+		} else
+		{
+			values[sparse[key]] = std::move(value);
+		}
+	}
+
 	// Retrieve a value by key
-	const Value &get(const Key key) const
+	inline const Value &get(const Key key) const
 	{
 		if (!contains(key))
 		{
@@ -68,7 +92,7 @@ class SparseSet {
 	}
 
 	// Retrieve a value by key
-	Value &get(const Key key)
+	inline Value &get(const Key key)
 	{
 		if (!contains(key))
 		{
@@ -77,11 +101,11 @@ class SparseSet {
 		return values[sparse[key]];
 	}
 
-	const Value &operator[](const Key key) const { return values[sparse[key]]; }
-	Value &operator[](const Key key) { return values[sparse[key]]; }
+	inline const Value &operator[](const Key key) const { return values[sparse[key]]; }
+	inline Value &operator[](const Key key) { return values[sparse[key]]; }
 
 	// Remove a value associated with a key
-	void remove(const Key key)
+	inline void remove(const Key key)
 	{
 		if (contains(key))
 		{
@@ -104,7 +128,7 @@ class SparseSet {
 
 	// Iterate over all values
 	template <typename Func>
-	void forEach(Func f)
+	inline void forEach(Func f)
 	{
 		for (size_t i = 0; i < values.size(); ++i)
 		{
@@ -112,15 +136,18 @@ class SparseSet {
 		}
 	}
 
-	bool contains(const Key key) const { return key < sparse.size() && sparse[key] != std::numeric_limits<Key>::max(); }
+	constexpr bool contains(const Key key) const
+	{
+		return key < sparse.size() && sparse[key] != std::numeric_limits<Key>::max();
+	}
 
-	size_t size() const { return dense.size(); }
+	constexpr size_t size() const { return dense.size(); }
 
-	const std::vector<Key> &getKeys() const { return dense; }
+	inline const std::vector<Key> &getKeys() const { return dense; }
 
-	std::vector<Value> &getValues() { return values; }
+	inline std::vector<Value> &getValues() { return values; }
 
-	const std::vector<Value> &getValues() const { return values; }
+	inline const std::vector<Value> &getValues() const { return values; }
 
 	constexpr size_t maxSize() const noexcept
 	{
@@ -128,7 +155,7 @@ class SparseSet {
 		return std::min({maxKeyVal, dense.max_size(), values.max_size()});
 	}
 
-	void clear()
+	inline void clear()
 	{
 		sparse.clear();
 		dense.clear();

--- a/tests/ecs.benchmark.cpp
+++ b/tests/ecs.benchmark.cpp
@@ -1,20 +1,15 @@
 #define CATCH_CONFIG_RUNNER
 
-#define EASYS_ENTITY_LIMIT 100000
+#define EASYS_ENTITY_LIMIT 1000000
 
 #include <catch2/catch.hpp>
 #include <chrono>
 #include <easys/ecs.hpp>
 #include <easys/entity.hpp>
 
-#define NUM_ENT MAX_ENTITIES // number of entities
-#define NUM_COM 1            // number of components per entity
-
-using namespace Easys;
-
-struct System {
-	virtual void update(ECS &ecs, double deltaTime) = 0;
-};
+#define NUM_ENT Easys::MAX_ENTITIES  // number of entities
+#define NUM_COM 1                    // number of components per entity
+#define COMPTYPES Position, RigidBody, Data, Health, Damage, TestComponent, AnotherComponent
 
 struct Position {
 	float x, y;
@@ -35,6 +30,22 @@ struct Health {
 
 struct Damage {
 	int damage;
+};
+
+struct TestComponent {
+	int value;
+};
+
+struct AnotherComponent {
+	float value;
+};
+
+// using namespace Easys;
+using ECS = Easys::ECS<COMPTYPES>;
+using Entity = Easys::Entity;
+
+struct System {
+	virtual void update(ECS &ecs, double deltaTime) = 0;
 };
 
 // CATCH_CONFIG_RUNNER tells catch2, that we will implement our own main function to config the test runner.
@@ -69,7 +80,7 @@ void benchmarkSection(Func func, const std::string &sectionName)
 {
 	auto start = std::chrono::high_resolution_clock::now();
 
-	func(); // Execute the lambda function
+	func();  // Execute the lambda function
 
 	auto end = std::chrono::high_resolution_clock::now();
 	std::chrono::duration<double, std::milli> elapsed = end - start;
@@ -80,16 +91,8 @@ void benchmarkSection(Func func, const std::string &sectionName)
 
 TEST_CASE("ECS Benchmark", "[ECS]")
 {
-	struct TestComponent {
-		int value;
-	};
-
-	struct AnotherComponent {
-		float value;
-	};
-
 	class MockSystem : public System {
-	  public:
+	   public:
 		bool updateCalled = false;
 
 		void update(ECS &ecs, double deltaTime) override { updateCalled = true; }
@@ -100,8 +103,10 @@ TEST_CASE("ECS Benchmark", "[ECS]")
 		ECS ecs;
 
 		benchmarkSection(
-		    [&] {
-			    for (int i = 0; i < NUM_ENT; i++) {
+		    [&]
+		    {
+			    for (int i = 0; i < NUM_ENT; i++)
+			    {
 				    ecs.addEntity();
 			    }
 		    },
@@ -112,13 +117,16 @@ TEST_CASE("ECS Benchmark", "[ECS]")
 	{
 		ECS ecs;
 
-		for (int i = 0; i < NUM_ENT; i++) {
+		for (int i = 0; i < NUM_ENT; i++)
+		{
 			Entity e = ecs.addEntity();
 		}
 
 		benchmarkSection(
-		    [&] {
-			    for (int i = 0; i < NUM_ENT; i++) {
+		    [&]
+		    {
+			    for (int i = 0; i < NUM_ENT; i++)
+			    {
 				    ecs.removeEntity(i);
 			    }
 		    },
@@ -130,13 +138,16 @@ TEST_CASE("ECS Benchmark", "[ECS]")
 		ECS ecs;
 		TestComponent c = TestComponent{};
 
-		for (int i = 0; i < NUM_ENT; i++) {
+		for (int i = 0; i < NUM_ENT; i++)
+		{
 			Entity e = ecs.addEntity();
 		}
 
 		benchmarkSection(
-		    [&] {
-			    for (int i = 0; i < NUM_ENT; i++) {
+		    [&]
+		    {
+			    for (int i = 0; i < NUM_ENT; i++)
+			    {
 				    ecs.addComponent<TestComponent>(i, c);
 			    }
 		    },
@@ -149,13 +160,16 @@ TEST_CASE("ECS Benchmark", "[ECS]")
 		TestComponent c = TestComponent{};
 		AnotherComponent a = AnotherComponent{};
 
-		for (int i = 0; i < NUM_ENT; i++) {
+		for (int i = 0; i < NUM_ENT; i++)
+		{
 			Entity e = ecs.addEntity();
 		}
 
 		benchmarkSection(
-		    [&] {
-			    for (int i = 0; i < NUM_ENT; i++) {
+		    [&]
+		    {
+			    for (int i = 0; i < NUM_ENT; i++)
+			    {
 				    ecs.addComponent<TestComponent>(i, c);
 				    ecs.addComponent<AnotherComponent>(i, a);
 			    }
@@ -168,14 +182,17 @@ TEST_CASE("ECS Benchmark", "[ECS]")
 		ECS ecs;
 		TestComponent c = TestComponent{};
 
-		for (int i = 0; i < NUM_ENT; i++) {
+		for (int i = 0; i < NUM_ENT; i++)
+		{
 			Entity e = ecs.addEntity();
 			ecs.addComponent<TestComponent>(e, c);
 		}
 
 		benchmarkSection(
-		    [&] {
-			    for (int i = 0; i < NUM_ENT; i++) {
+		    [&]
+		    {
+			    for (int i = 0; i < NUM_ENT; i++)
+			    {
 				    ecs.removeComponent<TestComponent>(i);
 			    }
 		    },
@@ -187,14 +204,17 @@ TEST_CASE("ECS Benchmark", "[ECS]")
 		ECS ecs;
 		TestComponent c = TestComponent{};
 
-		for (int i = 0; i < NUM_ENT; i++) {
+		for (int i = 0; i < NUM_ENT; i++)
+		{
 			Entity e = ecs.addEntity();
 			ecs.addComponent<TestComponent>(e, c);
 		}
 
 		benchmarkSection(
-		    [&] {
-			    for (int i = 0; i < NUM_ENT; i++) {
+		    [&]
+		    {
+			    for (int i = 0; i < NUM_ENT; i++)
+			    {
 				    ecs.getComponent<TestComponent>(i);
 			    }
 		    },
@@ -206,15 +226,19 @@ TEST_CASE("ECS Benchmark", "[ECS]")
 		ECS ecs;
 		TestComponent c = TestComponent{};
 
-		for (int i = 0; i < NUM_ENT; i++) {
+		for (int i = 0; i < NUM_ENT; i++)
+		{
 			Entity e = ecs.addEntity();
 			ecs.addComponent<TestComponent>(e, c);
 		}
 
+		volatile int sink = 0;
 		benchmarkSection(
-		    [&] {
-			    for (int i = 0; i < NUM_ENT; i++) {
-				    ecs.hasComponent<TestComponent>(i);
+		    [&]
+		    {
+			    for (int i = 0; i < NUM_ENT; i++)
+			    {
+				    sink += ecs.hasComponent<TestComponent>(i);
 			    }
 		    },
 		    formatEntCompInfo("hascomponent", NUM_ENT, NUM_COM));
@@ -225,15 +249,19 @@ TEST_CASE("ECS Benchmark", "[ECS]")
 		ECS ecs;
 		TestComponent c = TestComponent{};
 
-		for (int i = 0; i < NUM_ENT; i++) {
+		for (int i = 0; i < NUM_ENT; i++)
+		{
 			Entity e = ecs.addEntity();
 		}
 		ecs.addComponent<TestComponent>(0, c);
 
+		volatile int sink = 0;
 		benchmarkSection(
-		    [&] {
-			    for (int i = 0; i < NUM_ENT; i++) {
-				    ecs.hasComponent<TestComponent>(i);
+		    [&]
+		    {
+			    for (int i = 0; i < NUM_ENT; i++)
+			    {
+				    sink += ecs.hasComponent<TestComponent>(i);
 			    }
 		    },
 		    formatEntCompInfo("hasComponent", NUM_ENT, 0));
@@ -248,8 +276,10 @@ TEST_CASE("ECS Benchmark", "[ECS]")
 		struct TestPhysicsSystem : public System {
 			void update(ECS &ecs, double deltaTime)
 			{
-				for (const Entity &entity : ecs.getEntities()) {
-					if (ecs.hasComponent<RigidBody>(entity) && ecs.hasComponent<Position>(entity)) {
+				for (const Entity &entity : ecs.getEntities())
+				{
+					if (ecs.hasComponent<RigidBody>(entity) && ecs.hasComponent<Position>(entity))
+					{
 						auto &position = ecs.getComponent<Position>(entity);
 						auto &rigidBody = ecs.getComponent<RigidBody>(entity);
 						position.x += rigidBody.vx;
@@ -262,8 +292,10 @@ TEST_CASE("ECS Benchmark", "[ECS]")
 		struct TestUpdateSystem : public System {
 			void update(ECS &ecs, double deltaTime)
 			{
-				for (const Entity &entity : ecs.getEntities()) {
-					if (ecs.hasComponent<RigidBody>(entity) && ecs.hasComponent<Position>(entity)) {
+				for (const Entity &entity : ecs.getEntities())
+				{
+					if (ecs.hasComponent<RigidBody>(entity) && ecs.hasComponent<Position>(entity))
+					{
 						auto &position = ecs.getComponent<Position>(entity);
 						auto &rigidBody = ecs.getComponent<RigidBody>(entity);
 						position.x = rigidBody.vx;
@@ -277,14 +309,16 @@ TEST_CASE("ECS Benchmark", "[ECS]")
 		TestUpdateSystem testUpdateSystem = TestUpdateSystem();
 		double deltaTime = 0.0;
 
-		for (int i = 0; i < NUM_ENT; i++) {
+		for (int i = 0; i < NUM_ENT; i++)
+		{
 			Entity e = ecs.addEntity();
 			ecs.addComponent<Position>(e, p);
 			ecs.addComponent<RigidBody>(e, r);
 		}
 
 		benchmarkSection(
-		    [&] {
+		    [&]
+		    {
 			    testPhysicsSystem.update(ecs, deltaTime);
 			    testUpdateSystem.update(ecs, deltaTime);
 			    testPhysicsSystem.update(ecs, deltaTime);
@@ -310,7 +344,8 @@ TEST_CASE("ECS Benchmark", "[ECS]")
 		struct MovementSystem : public System {
 			void update(ECS &ecs, double deltaTime) override
 			{
-				for (const Entity &entity : ecs.getEntities()) {
+				for (const Entity &entity : ecs.getEntities())
+				{
 					auto &position = ecs.getComponent<Position>(entity);
 					auto &rigidBody = ecs.getComponent<RigidBody>(entity);
 					position.x += rigidBody.vx * deltaTime;
@@ -322,7 +357,8 @@ TEST_CASE("ECS Benchmark", "[ECS]")
 		struct DataSystem : public System {
 			void update(ECS &ecs, double deltaTime) override
 			{
-				for (const Entity &entity : ecs.getEntities()) {
+				for (const Entity &entity : ecs.getEntities())
+				{
 					auto &data = ecs.getComponent<Data>(entity);
 					// Update data with arbitrary logic
 					data.data = "new data";
@@ -333,7 +369,8 @@ TEST_CASE("ECS Benchmark", "[ECS]")
 		struct MoreComplexSystem : public System {
 			void update(ECS &ecs, double deltaTime) override
 			{
-				for (const Entity &entity : ecs.getEntities()) {
+				for (const Entity &entity : ecs.getEntities())
+				{
 					auto &pos = ecs.getComponent<Position>(entity);
 					auto &vel = ecs.getComponent<RigidBody>(entity);
 					auto &data = ecs.getComponent<Data>(entity);
@@ -347,12 +384,11 @@ TEST_CASE("ECS Benchmark", "[ECS]")
 		struct HealthSystem : public System {
 			void update(ECS &ecs, double deltaTime) override
 			{
-				for (const Entity &entity : ecs.getEntities()) {
+				for (const Entity &entity : ecs.getEntities())
+				{
 					auto &health = ecs.getComponent<Health>(entity);
-					if (health.health > health.maxHealth)
-						health.health = health.maxHealth;
-					if (health.health < health.maxHealth)
-						health.health = 0;
+					if (health.health > health.maxHealth) health.health = health.maxHealth;
+					if (health.health < health.maxHealth) health.health = 0;
 				}
 			}
 		};
@@ -360,10 +396,11 @@ TEST_CASE("ECS Benchmark", "[ECS]")
 		struct DamageSystem : public System {
 			void update(ECS &ecs, double deltaTime) override
 			{
-				for (const Entity &entity : ecs.getEntities()) {
+				for (const Entity &entity : ecs.getEntities())
+				{
 					auto &health = ecs.getComponent<Health>(entity);
 					auto &damage = ecs.getComponent<Damage>(entity);
-					health.health -= damage.damage; // Simplified damage logic
+					health.health -= damage.damage;  // Simplified damage logic
 				}
 			}
 		};
@@ -375,9 +412,10 @@ TEST_CASE("ECS Benchmark", "[ECS]")
 		HealthSystem healthSystem = HealthSystem();
 		DamageSystem damageSystem = DamageSystem();
 
-		double deltaTime = 0.016; // Assuming 60 FPS for deltaTime
+		double deltaTime = 0.016;  // Assuming 60 FPS for deltaTime
 
-		for (int i = 0; i < NUM_ENT; i++) {
+		for (int i = 0; i < NUM_ENT; i++)
+		{
 			Entity e = ecs.addEntity();
 			ecs.addComponent<Position>(e, position);
 			ecs.addComponent<RigidBody>(e, velocity);
@@ -387,7 +425,8 @@ TEST_CASE("ECS Benchmark", "[ECS]")
 		}
 
 		benchmarkSection(
-		    [&] {
+		    [&]
+		    {
 			    movementSystem.update(ecs, deltaTime);
 			    dataSystem.update(ecs, deltaTime);
 			    moreComplexSystem.update(ecs, deltaTime);

--- a/tests/ecs.benchmark.cpp
+++ b/tests/ecs.benchmark.cpp
@@ -45,11 +45,11 @@ using ECS = Easys::ECS<COMPTYPES>;
 using Entity = Easys::Entity;
 
 struct System {
-	virtual void update(ECS &ecs, double deltaTime) = 0;
+	virtual void update(ECS& ecs, double deltaTime) = 0;
 };
 
 // CATCH_CONFIG_RUNNER tells catch2, that we will implement our own main function to config the test runner.
-int main(int argc, char *argv[])
+int main(int argc, char* argv[])
 {
 	Catch::Session session;
 
@@ -76,7 +76,7 @@ std::string formatEntCompInfo(const std::string functionName, const int numEntit
 // This function is a helper to run benchmarks. It  that takes a lambda function as an argument.
 // This lambda function will contain the code to benchmark.
 template <typename Func>
-void benchmarkSection(Func func, const std::string &sectionName)
+void benchmarkSection(Func func, const std::string& sectionName)
 {
 	auto start = std::chrono::high_resolution_clock::now();
 
@@ -95,7 +95,7 @@ TEST_CASE("ECS Benchmark", "[ECS]")
 	   public:
 		bool updateCalled = false;
 
-		void update(ECS &ecs, double deltaTime) override { updateCalled = true; }
+		void update(ECS& ecs, double deltaTime) override { updateCalled = true; }
 	};
 
 	SECTION("Benchmarking Entity Addition")
@@ -275,14 +275,14 @@ TEST_CASE("ECS Benchmark", "[ECS]")
 		RigidBody r = RigidBody{};
 
 		struct TestPhysicsSystem : public System {
-			void update(ECS &ecs, double deltaTime)
+			void update(ECS& ecs, double deltaTime)
 			{
-				for (const Entity &entity : ecs.getEntities())
+				for (const Entity& entity : ecs.getEntities())
 				{
 					if (ecs.hasComponent<RigidBody>(entity) && ecs.hasComponent<Position>(entity))
 					{
-						auto &position = ecs.getComponent<Position>(entity);
-						auto &rigidBody = ecs.getComponent<RigidBody>(entity);
+						auto& position = ecs.getComponent<Position>(entity);
+						auto& rigidBody = ecs.getComponent<RigidBody>(entity);
 						position.x += rigidBody.vx;
 						position.y += rigidBody.vy;
 					}
@@ -291,14 +291,14 @@ TEST_CASE("ECS Benchmark", "[ECS]")
 		};
 
 		struct TestUpdateSystem : public System {
-			void update(ECS &ecs, double deltaTime)
+			void update(ECS& ecs, double deltaTime)
 			{
-				for (const Entity &entity : ecs.getEntities())
+				for (const Entity& entity : ecs.getEntities())
 				{
 					if (ecs.hasComponent<RigidBody>(entity) && ecs.hasComponent<Position>(entity))
 					{
-						auto &position = ecs.getComponent<Position>(entity);
-						auto &rigidBody = ecs.getComponent<RigidBody>(entity);
+						auto& position = ecs.getComponent<Position>(entity);
+						auto& rigidBody = ecs.getComponent<RigidBody>(entity);
 						position.x = rigidBody.vx;
 						position.y = rigidBody.vy;
 					}
@@ -343,12 +343,12 @@ TEST_CASE("ECS Benchmark", "[ECS]")
 
 		// Systems definition
 		struct MovementSystem : public System {
-			void update(ECS &ecs, double deltaTime) override
+			void update(ECS& ecs, double deltaTime) override
 			{
-				for (const Entity &entity : ecs.getEntities())
+				for (const Entity& entity : ecs.getEntities())
 				{
-					auto &position = ecs.getComponent<Position>(entity);
-					auto &rigidBody = ecs.getComponent<RigidBody>(entity);
+					auto& position = ecs.getComponent<Position>(entity);
+					auto& rigidBody = ecs.getComponent<RigidBody>(entity);
 					position.x += rigidBody.vx * deltaTime;
 					position.y += rigidBody.vy * deltaTime;
 				}
@@ -356,11 +356,11 @@ TEST_CASE("ECS Benchmark", "[ECS]")
 		};
 
 		struct DataSystem : public System {
-			void update(ECS &ecs, double deltaTime) override
+			void update(ECS& ecs, double deltaTime) override
 			{
-				for (const Entity &entity : ecs.getEntities())
+				for (const Entity& entity : ecs.getEntities())
 				{
-					auto &data = ecs.getComponent<Data>(entity);
+					auto& data = ecs.getComponent<Data>(entity);
 					// Update data with arbitrary logic
 					data.data = "new data";
 				}
@@ -368,13 +368,13 @@ TEST_CASE("ECS Benchmark", "[ECS]")
 		};
 
 		struct MoreComplexSystem : public System {
-			void update(ECS &ecs, double deltaTime) override
+			void update(ECS& ecs, double deltaTime) override
 			{
-				for (const Entity &entity : ecs.getEntities())
+				for (const Entity& entity : ecs.getEntities())
 				{
-					auto &pos = ecs.getComponent<Position>(entity);
-					auto &vel = ecs.getComponent<RigidBody>(entity);
-					auto &data = ecs.getComponent<Data>(entity);
+					auto& pos = ecs.getComponent<Position>(entity);
+					auto& vel = ecs.getComponent<RigidBody>(entity);
+					auto& data = ecs.getComponent<Data>(entity);
 					pos = {0, 0};
 					vel = {1, 1};
 					data.data = "data";
@@ -383,11 +383,11 @@ TEST_CASE("ECS Benchmark", "[ECS]")
 		};
 
 		struct HealthSystem : public System {
-			void update(ECS &ecs, double deltaTime) override
+			void update(ECS& ecs, double deltaTime) override
 			{
-				for (const Entity &entity : ecs.getEntities())
+				for (const Entity& entity : ecs.getEntities())
 				{
-					auto &health = ecs.getComponent<Health>(entity);
+					auto& health = ecs.getComponent<Health>(entity);
 					if (health.health > health.maxHealth) health.health = health.maxHealth;
 					if (health.health < health.maxHealth) health.health = 0;
 				}
@@ -395,12 +395,12 @@ TEST_CASE("ECS Benchmark", "[ECS]")
 		};
 
 		struct DamageSystem : public System {
-			void update(ECS &ecs, double deltaTime) override
+			void update(ECS& ecs, double deltaTime) override
 			{
-				for (const Entity &entity : ecs.getEntities())
+				for (const Entity& entity : ecs.getEntities())
 				{
-					auto &health = ecs.getComponent<Health>(entity);
-					auto &damage = ecs.getComponent<Damage>(entity);
+					auto& health = ecs.getComponent<Health>(entity);
+					auto& damage = ecs.getComponent<Damage>(entity);
 					health.health -= damage.damage;  // Simplified damage logic
 				}
 			}

--- a/tests/ecs.benchmark.cpp
+++ b/tests/ecs.benchmark.cpp
@@ -1,6 +1,6 @@
 #define CATCH_CONFIG_RUNNER
 
-#define EASYS_ENTITY_LIMIT 1000000
+#define EASYS_ENTITY_LIMIT 10000000
 
 #include <catch2/catch.hpp>
 #include <chrono>
@@ -210,12 +210,13 @@ TEST_CASE("ECS Benchmark", "[ECS]")
 			ecs.addComponent<TestComponent>(e, c);
 		}
 
+		TestComponent tc;
 		benchmarkSection(
 		    [&]
 		    {
 			    for (int i = 0; i < NUM_ENT; i++)
 			    {
-				    ecs.getComponent<TestComponent>(i);
+				    tc = ecs.getComponent<TestComponent>(i);
 			    }
 		    },
 		    formatEntCompInfo("getComponent", NUM_ENT, NUM_COM));

--- a/tests/ecs.test.cpp
+++ b/tests/ecs.test.cpp
@@ -5,6 +5,8 @@
 
 using namespace Easys;
 
+#define ECS_TEST_COMPTYPES TestComponent, AnotherComponent
+
 TEST_CASE("ECS Tests", "[ECS]")
 {
 	struct TestComponent {
@@ -15,7 +17,7 @@ TEST_CASE("ECS Tests", "[ECS]")
 		float value;
 	};
 
-	ECS ecs;
+	ECS<ECS_TEST_COMPTYPES> ecs;
 
 	// TODO: test constructors
 
@@ -96,7 +98,7 @@ TEST_CASE("ECS Tests", "[ECS]")
 		AnotherComponent comp3 = {5};
 		ecs.addComponent<TestComponent>(entity1, comp1);
 		ecs.addComponent<TestComponent>(entity2, comp2);
-		ecs.addComponent<AnotherComponent>(entity2, comp3); // should not be included in results
+		ecs.addComponent<AnotherComponent>(entity2, comp3);  // should not be included in results
 
 		auto testComponents = ecs.getEntitiesByComponent<TestComponent>();
 		REQUIRE(testComponents.size() == 2);
@@ -109,22 +111,23 @@ TEST_CASE("ECS Tests", "[ECS]")
 		Entity entity3 = ecs.addEntity();
 		TestComponent comp1 = {60};
 		AnotherComponent comp2 = {10.0f};
-		ecs.addComponent<TestComponent>(entity1, comp1);    // TestComponent only
-		ecs.addComponent<AnotherComponent>(entity2, comp2); // AnotherComponent only
+		ecs.addComponent<TestComponent>(entity1, comp1);     // TestComponent only
+		ecs.addComponent<AnotherComponent>(entity2, comp2);  // AnotherComponent only
 		ecs.addComponent<TestComponent>(entity3, comp1);
-		ecs.addComponent<AnotherComponent>(entity3, comp2); // Both components
+		ecs.addComponent<AnotherComponent>(entity3, comp2);  // Both components
 
-		struct ForeignComponent {}; // A (for the ECS) foreign component should not cause throw.
+		struct ForeignComponent {};  // A (for the ECS) foreign component should not cause throw.
 
 		REQUIRE(ecs.getEntitiesByComponents<TestComponent, AnotherComponent>().size() == 1);
 		REQUIRE(ecs.getEntitiesByComponents<TestComponent>().size() == 2);
 		REQUIRE(ecs.getEntitiesByComponents<AnotherComponent>().size() == 2);
-		REQUIRE(ecs.getEntitiesByComponents<AnotherComponent, ForeignComponent>().size() == 0);
+		// no need, since we do compile time. but stays here to test handling and error messages etc.
+		 //REQUIRE(ecs.getEntitiesByComponents<AnotherComponent, ForeignComponent>().size() == 0);
 	}
 
 	SECTION("getEntityCount returns correct number of entities", "[ECS]")
 	{
-		ECS ecs;
+		ECS<ECS_TEST_COMPTYPES> ecs;
 
 		REQUIRE(ecs.getEntityCount() == 0);
 
@@ -138,7 +141,7 @@ TEST_CASE("ECS Tests", "[ECS]")
 
 	SECTION("getComponentCount returns correct number of components", "[ECS]")
 	{
-		ECS ecs;
+		ECS<ECS_TEST_COMPTYPES> ecs;
 		Entity entity1 = ecs.addEntity();
 		Entity entity2 = ecs.addEntity();
 
@@ -163,7 +166,7 @@ TEST_CASE("ECS Tests", "[ECS]")
 
 	SECTION("Clearing ECS")
 	{
-		ECS ecs;
+		ECS<ECS_TEST_COMPTYPES> ecs;
 		auto entity = ecs.addEntity();
 		ecs.addComponent<TestComponent>(entity, TestComponent());
 		ecs.addComponent<AnotherComponent>(entity, AnotherComponent());
@@ -175,14 +178,14 @@ TEST_CASE("ECS Tests", "[ECS]")
 
 	SECTION("Clearing ECS")
 	{
-		ECS ecs;
+		ECS<ECS_TEST_COMPTYPES> ecs;
 		auto entity = ecs.addEntity();
 		ecs.addComponent<TestComponent>(entity, TestComponent());
 		ecs.addComponent<AnotherComponent>(entity, AnotherComponent());
 
 		ecs.clear();
 		REQUIRE(ecs.getEntityCount() == 0);
-		REQUIRE(ecs.addEntity() == 0); // Check if all entity IDs are available again
+		REQUIRE(ecs.addEntity() == 0);  // Check if all entity IDs are available again
 		REQUIRE(ecs.getComponentCount<TestComponent, AnotherComponent>() == 0);
 	}
 }

--- a/tests/ecs.test.cpp
+++ b/tests/ecs.test.cpp
@@ -51,7 +51,7 @@ TEST_CASE("ECS Tests", "[ECS]")
 		TestComponent comp = {20};
 		ecs.addComponent<TestComponent>(entity, comp);
 
-		TestComponent &retrievedComp = ecs.getComponent<TestComponent>(entity);
+		TestComponent& retrievedComp = ecs.getComponent<TestComponent>(entity);
 		REQUIRE(retrievedComp.data == 20);
 	}
 
@@ -122,7 +122,7 @@ TEST_CASE("ECS Tests", "[ECS]")
 		REQUIRE(ecs.getEntitiesByComponents<TestComponent>().size() == 2);
 		REQUIRE(ecs.getEntitiesByComponents<AnotherComponent>().size() == 2);
 		// no need, since we do compile time. but stays here to test handling and error messages etc.
-		 //REQUIRE(ecs.getEntitiesByComponents<AnotherComponent, ForeignComponent>().size() == 0);
+		// REQUIRE(ecs.getEntitiesByComponents<AnotherComponent, ForeignComponent>().size() == 0);
 	}
 
 	SECTION("getEntityCount returns correct number of entities", "[ECS]")

--- a/tests/registry.test.cpp
+++ b/tests/registry.test.cpp
@@ -30,7 +30,7 @@ TEST_CASE("Registry Tests", "[Registry]")
 		TestComponent comp = {20};
 		registry.addComponent<TestComponent>(testEntity, comp);
 
-		TestComponent &retrievedComp = registry.getComponent<TestComponent>(testEntity);
+		TestComponent& retrievedComp = registry.getComponent<TestComponent>(testEntity);
 		REQUIRE(retrievedComp.value == 20);
 	}
 
@@ -118,7 +118,7 @@ TEST_CASE("Registry Tests", "[Registry]")
 		registry.addComponent<TestComponent>(entity2, comp2);
 		registry.addComponent<AnotherComponent>(entity3, comp3);  // Different type, should not be included
 
-		auto &testComponents = registry.getEntitiesByComponent<TestComponent>();
+		auto& testComponents = registry.getEntitiesByComponent<TestComponent>();
 
 		REQUIRE(testComponents.size() == 2);
 		REQUIRE(testComponents[0] == entity1);
@@ -142,7 +142,7 @@ struct Health {
 #define REG_TEST_COMPTYPES Position, Velocity, Health
 
 // Utility function to add some entities and components to a registry for testing
-void setupRegistry(Registry<REG_TEST_COMPTYPES> &registry)
+void setupRegistry(Registry<REG_TEST_COMPTYPES>& registry)
 {
 	// Add entities with various components
 	for (int i = 0; i < 10; ++i)

--- a/tests/registry.test.cpp
+++ b/tests/registry.test.cpp
@@ -14,7 +14,7 @@ struct AnotherComponent {
 
 TEST_CASE("Registry Tests", "[Registry]")
 {
-	Registry registry;
+	Registry<COMPONENT_TYPES> registry;
 	Entity testEntity = 1;
 
 	SECTION("Add and Check Component")
@@ -58,14 +58,11 @@ TEST_CASE("Registry Tests", "[Registry]")
 		REQUIRE_FALSE(registry.hasComponent<AnotherComponent>(testEntity));
 	}
 
-	SECTION("ComponentType Does Not Exist")
-	{
-		REQUIRE_FALSE(registry.hasComponent<TestComponent>(testEntity));
-	}
+	SECTION("ComponentType Does Not Exist") { REQUIRE_FALSE(registry.hasComponent<TestComponent>(testEntity)); }
 
 	SECTION("Registry size method returns total number of components")
 	{
-		Registry registry;
+		Registry<COMPONENT_TYPES> registry;
 
 		REQUIRE(registry.size<COMPONENT_TYPES>() == 0);
 
@@ -88,7 +85,7 @@ TEST_CASE("Registry Tests", "[Registry]")
 
 	SECTION("Registry size method with single component type")
 	{
-		Registry registry;
+		Registry<COMPONENT_TYPES> registry;
 		Entity entity = 1;
 		TestComponent comp{0};
 		registry.addComponent<TestComponent>(entity, comp);
@@ -97,13 +94,13 @@ TEST_CASE("Registry Tests", "[Registry]")
 
 	SECTION("Registry size method with no known component types")
 	{
-		Registry registry;
+		Registry<COMPONENT_TYPES> registry;
 		REQUIRE(registry.size<COMPONENT_TYPES>() == 0);
 	}
 
 	SECTION("Registry size method with one unknown component type")
 	{
-		Registry registry;
+		Registry<COMPONENT_TYPES> registry;
 		Entity entity = 1;
 		TestComponent comp{0};
 		registry.addComponent<TestComponent>(entity, comp);
@@ -119,7 +116,7 @@ TEST_CASE("Registry Tests", "[Registry]")
 
 		registry.addComponent<TestComponent>(entity1, comp1);
 		registry.addComponent<TestComponent>(entity2, comp2);
-		registry.addComponent<AnotherComponent>(entity3, comp3); // Different type, should not be included
+		registry.addComponent<AnotherComponent>(entity3, comp3);  // Different type, should not be included
 
 		auto &testComponents = registry.getEntitiesByComponent<TestComponent>();
 
@@ -142,19 +139,25 @@ struct Health {
 	int points;
 };
 
+#define REG_TEST_COMPTYPES Position, Velocity, Health
+
 // Utility function to add some entities and components to a registry for testing
-void setupRegistry(Registry &registry)
+void setupRegistry(Registry<REG_TEST_COMPTYPES> &registry)
 {
 	// Add entities with various components
-	for (int i = 0; i < 10; ++i) {
-		Entity entity = i; // Assuming Entity can be an integer for simplicity
-		if (i % 2 == 0) {
+	for (int i = 0; i < 10; ++i)
+	{
+		Entity entity = i;  // Assuming Entity can be an integer for simplicity
+		if (i % 2 == 0)
+		{
 			registry.addComponent(entity, Position{1.0f * i, 2.0f * i});
 		}
-		if (i % 3 == 0) {
+		if (i % 3 == 0)
+		{
 			registry.addComponent(entity, Velocity{0.1f * i, 0.2f * i});
 		}
-		if (i % 5 == 0) {
+		if (i % 5 == 0)
+		{
 			registry.addComponent(entity, Health{i * 10});
 		}
 	}
@@ -162,44 +165,44 @@ void setupRegistry(Registry &registry)
 
 TEST_CASE("getEntitiesByComponents with single component type", "[Registry]")
 {
-	Registry registry;
+	Registry<REG_TEST_COMPTYPES> registry;
 	setupRegistry(registry);
 
 	auto entitiesWithPosition = registry.getEntitiesByComponents<Position>();
-	REQUIRE(entitiesWithPosition.size() == 5); // Entities 0, 2, 4, 6, 8
+	REQUIRE(entitiesWithPosition.size() == 5);  // Entities 0, 2, 4, 6, 8
 }
 
 TEST_CASE("getEntitiesByComponents with multiple component types", "[Registry]")
 {
-	Registry registry;
+	Registry<REG_TEST_COMPTYPES> registry;
 	setupRegistry(registry);
 
 	SECTION("Position and Velocity")
 	{
 		auto entitiesWithPositionAndVelocity = registry.getEntitiesByComponents<Position, Velocity>();
-		REQUIRE(entitiesWithPositionAndVelocity.size() == 2); // Entities 0, 6
+		REQUIRE(entitiesWithPositionAndVelocity.size() == 2);  // Entities 0, 6
 	}
 
 	SECTION("Position, Velocity, and Health")
 	{
 		auto entitiesWithAllComponents = registry.getEntitiesByComponents<Position, Velocity, Health>();
-		REQUIRE(entitiesWithAllComponents.size() == 1); // Entities 0
+		REQUIRE(entitiesWithAllComponents.size() == 1);  // Entities 0
 		REQUIRE(registry.getEntitiesByComponent<Health>().size() == 2);
 	}
 }
 
 TEST_CASE("getEntitiesByComponents with no entities matching", "[Registry]")
 {
-	Registry registry;
+	Registry<REG_TEST_COMPTYPES> registry;
 	setupRegistry(registry);
 
 	auto entitiesWithNonExistingCombination = registry.getEntitiesByComponents<Health, Velocity>();
-	REQUIRE(entitiesWithNonExistingCombination.size() == 1); // Only entity 0 matches this combination based on setup
+	REQUIRE(entitiesWithNonExistingCombination.size() == 1);  // Only entity 0 matches this combination based on setup
 }
 
 TEST_CASE("Registry clear functionality", "[Registry]")
 {
-	Registry registry;
+	Registry<REG_TEST_COMPTYPES> registry;
 	Entity entity = 1;
 	registry.addComponent<Position>(entity, {1.0f, 2.0f});
 	registry.addComponent<Velocity>(entity, {0.5f, 0.5f});

--- a/tests/sparse_set.test.cpp
+++ b/tests/sparse_set.test.cpp
@@ -64,7 +64,11 @@ TEST_CASE("SparseSet functionality", "[SparseSet]")
 		std::vector<unsigned int> keys;
 		set.set(1, 100);
 		set.set(2, 200);
-		set.forEach([&keys](auto key, auto value) { keys.push_back(key); });
+		set.forEach(
+		    [&keys](auto key, auto value)
+		    {
+			    keys.push_back(key);
+		    });
 
 		REQUIRE(keys.size() == 2);
 		REQUIRE(std::find(keys.begin(), keys.end(), 1) != keys.end());
@@ -78,8 +82,8 @@ TEST_CASE("SparseSet accommodate method tests", "[SparseSet]")
 
 	SECTION("Accommodate increases size for new key")
 	{
-		set.accommodate(10);                // Choose a key that requires resizing
-		REQUIRE(set.getKeys().size() == 0); // No keys should be added, just accommodation
+		set.accommodate(10);                 // Choose a key that requires resizing
+		REQUIRE(set.getKeys().size() == 0);  // No keys should be added, just accommodation
 		// REQUIRE(set.sparse.size() >= 11);   // Check if sparse size is correctly adjusted
 	}
 
@@ -116,11 +120,11 @@ TEST_CASE("SparseSet clear functionality", "[SparseSet]")
 {
 	SparseSet<Entity, Position> sparseSet;
 	// Setup initial state
-	sparseSet.set(1, {1.0f, 2.0f}); // Example entity and component
+	sparseSet.set(1, {1.0f, 2.0f});  // Example entity and component
 
 	SECTION("Clearing the SparseSet")
 	{
 		sparseSet.clear();
-		REQUIRE(sparseSet.size() == 0); // Ensure the sparse set is empty
+		REQUIRE(sparseSet.size() == 0);  // Ensure the sparse set is empty
 	}
 }


### PR DESCRIPTION
Switch ECS registry from runtime `SparseSet<Entity, std::any>` map to compile-time `std::tuple` of `SparseSet<Entity, ComponentType>`

- Replaced runtime component storage with compile-time tuple-based storage for stronger type safety and performance (over 10x across the board)
- Updated utility functions to work with the new model
- Improved error messages for unregistered components using static_assert